### PR TITLE
Reduce `_isChildOf` run time cost

### DIFF
--- a/src/crdt/type.js
+++ b/src/crdt/type.js
@@ -14,8 +14,8 @@ module.exports = (typeName, type, id, log, network, validate, create) => {
   }
 
   validate = validate || function (id, value) {
-    return true;
-  };
+    return true
+  }
 
   const embeds = new Map()
 
@@ -34,7 +34,7 @@ module.exports = (typeName, type, id, log, network, validate, create) => {
     _peerCRDTId: id,
     _isPeerCRDT: true,
     _type: typeName,
-    _insert: (value) => {
+    _insert: (value, entry) => {
       state = type.reduce.call(null, value, state, changed)
       const changes = changesToEmit
       changesToEmit = []
@@ -61,10 +61,10 @@ module.exports = (typeName, type, id, log, network, validate, create) => {
     pull.filter((entry) => entry.value !== undefined && entry.value !== null),
     pull.map((entry) => {
       const value = resolveReducerArg(entry.value)
-      if (!value) return;
-      const valid = validate(id, value);
-      if (!valid) return;
-      self._insert(value);
+      if (!value) return
+      const valid = validate(id, value)
+      if (!valid) return
+      self._insert(value, entry)
     }),
     pull.onEnd((err) => {
       throw err || new Error('follow stream should not have ended')


### PR DESCRIPTION
I conducted tests where three peers were randomly picked to apply a set of 500 or 1000 changes.

Using this patch, it took:

- 20-30 seconds to converge on 500 changes
- 70-80 seconds to converge on 1000 changes

Without this patch, it took:

- 17 minutes to converge on 500 changes
- 1000 changes ran for 5 hours and then crashed from lack of memory

The original code has two issues:

1. Does not stop processing once an answer is found.
2. Does not remember which nodes have been checked.

In a DAG that has many forks and merges, such as this test, those two
conditions meant that an extreme amount of time was spent _repeatedly_
searching the tree for a target node that was already found.