### PR TITLE
Change recursive item fetching with iterative, short-circuiting version

### DIFF
--- a/test/types.spec.js
+++ b/test/types.spec.js
@@ -14,7 +14,7 @@ const CRDT = require('../')
 const encrypt = require('./helpers/encrypt')
 const decrypt = require('./helpers/decrypt')
 
-const A_BIT = 500
+const A_BIT = 1000
 
 describe('types', () => {
   let myCRDT


### PR DESCRIPTION
Using same approach as #8 to replace recursive fetching to prevent fetching every _path_ through the DAG.